### PR TITLE
Fix for binding to Duckdb binding to ipv6 localhost

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -21,8 +21,8 @@ frontend https_front
     default_backend app_backend
 
 backend app_backend
-    server app1 127.0.0.1:4213
-    http-request set-header Host 127.0.0.1:4213
+    server app1 [::1]:4213
+    http-request set-header Host [::1]:4213
     http-request set-header Origin http://localhost:4213
     http-request set-header Referer http://localhost:4213/
     http-request del-header X-Forwarded-For


### PR DESCRIPTION
It seems that the duckdb local ui is binding to the localhost ipv6 addr [::1]. This is a simple fix to change haproxy conf to use that address as backend.